### PR TITLE
Correctly split hg38 HLA contigs during configuration

### DIFF
--- a/src/python/lib/checkChromSet.py
+++ b/src/python/lib/checkChromSet.py
@@ -81,7 +81,7 @@ def getBamChromInfo(samtoolsBin,bam) :
 
         h = {}
         for word in w[1:] :
-            vals=word.split(':')
+            vals=word.split(':', 1)
             h[vals[0]] = vals[1]
 
         key = h["SN"]


### PR DESCRIPTION
Chris;
I've been testing manta on hg38 and ran into a small issue with HLA contig parsing fixed here. There is also a downstream issue which I can work around with more details below. With these two fixes in place we can run on 38 without any issues and get similar sensitivity/precision to build 37.

When testing manta on hg38 full from the 1000 genomes distribution,
there are problems handling the HLA contigs, which contain colons: `HLA-A*01:01:01:01`.

Configuration fails with:
```
CONFIGURATION ERROR:
Reference fasta and 'Normal' BAM/CRAM file conflict on chromosome: 'HLA-A*01'
```
when splitting the names from the BAM tags. This small fix resolves the
problem. When running, there is also a downstream failure with a similar
problem trying to parse ranges in names with colons:
```
FATAL_ERROR: EstimateSVLoci EXCEPTION: ERROR: can't parse bam_region [err 1] HLA-A*01:01:01:02N:1-3291
```
I worked around this by excluding HLA regions from manta, with
`--region` but just as an additional related source of issues.