### PR TITLE
[#43] fix freed string pointer use in sample name

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,4 @@
+- [#43] fix freed string pointer use in sample name
 v0.29.6
 - MANTA-287 add the unit test of consistency of supporting reads
 - MANTA-287 fix a bug in the small assembler by checking consistency when adding a new supporting read of contig

--- a/src/c++/lib/applications/GenerateSVCandidates/SVScorer.cpp
+++ b/src/c++/lib/applications/GenerateSVCandidates/SVScorer.cpp
@@ -99,10 +99,9 @@ SVScorer(
     for (unsigned bamIndex(0); bamIndex<bamCount; ++bamIndex)
     {
         const bam_hdr_t* indexHeader(_bamStreams[bamIndex]->get_header());
-        std::ostringstream oss;
-        oss << "SAMPLE" << bamIndex;
-        const char* defaultName(oss.str().c_str());
-        std::string name(get_bam_header_sample_name(indexHeader,defaultName));
+        std::ostringstream defaultName;
+        defaultName << "SAMPLE" << (bamIndex+1);
+        std::string name(get_bam_header_sample_name(indexHeader,defaultName.str().c_str()));
         // remove spaces from sample name for everyone's sanity:
         std::replace(name.begin(), name.end(), ' ', '_');
         _sampleNames.push_back(name);

--- a/src/c++/lib/htsapi/bam_header_util.cpp
+++ b/src/c++/lib/htsapi/bam_header_util.cpp
@@ -191,6 +191,7 @@ get_bam_header_sample_name(
     const char* default_sample_name)
 {
     assert(header != nullptr);
+    assert(default_sample_name != nullptr);
 
     std::vector<std::string> lines;
     std::vector<std::string> words;
@@ -214,3 +215,4 @@ get_bam_header_sample_name(
     }
     return default_sample_name;
 }
+


### PR DESCRIPTION
The default sample name provided when no entry could be parsed
from the alignment file was using a string pointer from a deleted
temporary object. Thanks to @asrichter for reporting the incorrect
default sample name behavior.

The default sample name scheme was also corrected from zero-indexed
(SAMPLE0,SAMPLE1...) to 1-indexed (SAMPLE1,SAMPLE2..) to match indended
behavior and user guide documentation.