### PR TITLE
Increase the max allowed base Q score from 70 to 93

### DIFF
--- a/src/c++/lib/blt_util/qscore_cache.hpp
+++ b/src/c++/lib/blt_util/qscore_cache.hpp
@@ -43,7 +43,7 @@ struct qphred_cache {
     return qc().get_mapped_qscore_imp(basecall_qscore, mapping_qscore);
   }
 
-  enum { MAX_QSCORE = 70, MAX_MAP = 90 };
+  enum { MAX_QSCORE = 93, MAX_MAP = 90 };
 
   static void qscore_check(const int qscore, const char* label)
   {


### PR DESCRIPTION
There are now error-corrected NGS technologies that can produce base quality scores Q60+. To make those technologies compatible with the Manta program, we need to increase the maximum allowed base quality score. A score of 93 is the maximum defined in the [SAM spec v1](https://samtools.github.io/hts-specs/SAMv1.pdf) §4.2.3:

> Base qualities are stored as bytes in the range [0, 93], without any +33 conversion to printable ASCII. 

This is also the maximum for the [HTSJDK project](https://github.com/samtools/htsjdk/blob/f461401e38fe95362a6d3c5afd8b592964b4bd29/src/main/java/htsjdk/samtools/SAMUtils.java#L117).

