### PR TITLE
Filter bad-cigar reads in bam streamer

### DIFF
--- a/src/c++/lib/htsapi/bam_streamer.hpp
+++ b/src/c++/lib/htsapi/bam_streamer.hpp
@@ -76,6 +76,7 @@ struct bam_streamer : public stream_state_reporter, public boost::noncopyable {
   void resetRegion(int referenceContigId, int beginPos, int endPos);
 
   bool next();
+  bool next0();
 
   const bam_record* get_record_ptr() const
   {


### PR DESCRIPTION
These reads are ok according to SAM/BAM spec, but Manta can't work with them.

This fixes issue https://github.com/Illumina/manta/issues/137 "Manta crashes on input files realigned with ABRA #137"
as well as issue https://github.com/Illumina/manta/issues/184 "Unclear how to deal with CIGAR strings with InDels at the end of reads"

The fix is to remove offending alignments in the bam streamer instead of throwing an exception much later in the code. This has the same effect as pre-filtering the alignments using awk (as described in issue 184), but it is much faster.