### PR TITLE
Fixes #293

### DIFF
--- a/src/python/lib/makeRunScript.py
+++ b/src/python/lib/makeRunScript.py
@@ -129,7 +129,7 @@ results -- in this case the dry run will not cover the full 'live' run task set.
     def isLocalSmtp() :
         import smtplib
         try :
-            smtplib.SMTP('localhost')
+            smtplib.SMTP('localhost', 25, 'localhost', 5)
         except :
             return False
         return True


### PR DESCRIPTION
Adding a timeout of 5 seconds to `smtplib.SMTP()` allows the script to continue when the port is blocking.